### PR TITLE

Refactor README and lint-elisp.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- ---
-!-- Timestamp: 2025-01-25 02:06:42
+!-- Timestamp: 2025-01-25 02:20:38
 !-- Author: ywatanabe
 !-- File: /home/ywatanabe/proj/lint-elisp/README.md
 !-- --- -->
@@ -33,10 +33,6 @@ A simple Emacs package for formatting Elisp code with consistent style.
           (lambda ()
             (add-hook 'before-save-hook 'lint-this-elisp-buffer nil t)))
 ```
-
-## License
-
-MIT
 
 ## Contact
 

--- a/lint-elisp.el
+++ b/lint-elisp.el
@@ -1,6 +1,6 @@
 ;;; -*- coding: utf-8; lexical-binding: t -*-
-;;; Author: 2025-01-25 02:07:05
-;;; Timestamp: <2025-01-25 02:07:05>
+;;; Author: 2025-01-25 02:21:17
+;;; Timestamp: <2025-01-25 02:21:17>
 ;;; File: /home/ywatanabe/proj/lint-elisp/lint-elisp.el
 
 
@@ -151,3 +151,5 @@ and adds newlines before parentheses and comments."
 ;;           (lambda ()
 ;;             (add-hook 'before-save-hook 'lint-this-elisp-buffer nil t)))
 ;; ;; EOF
+
+(provide 'lint-elisp)


### PR DESCRIPTION

- Removed the license section from the README.md.
- Added a `provide` statement to `lint-elisp.el`.
- This ensures that `lint-elisp.el` can be properly required.
- The changes make the package more modular.
- The removal simplifies README by concentrating to core functionality.
- None
- None